### PR TITLE
バインドエラー改修

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -34,7 +34,7 @@ jobs:
         run: dotnet nuget add source --username YoshikazuArimitsu --password "$env:PACKAGE_TOKEN" --store-password-in-clear-text --name github "https://nuget.pkg.github.com/YoshikazuArimitsu/index.json"
 
       - name: Publish GitHub
-        run: dotnet nuget push "artifacts/HtmlMailControlWpf.0.0.15.nupkg" --api-key "$env:PACKAGE_TOKEN" --source "github"
+        run: dotnet nuget push "artifacts/HtmlMailControlWpf.0.0.16.nupkg" --api-key "$env:PACKAGE_TOKEN" --source "github"
 
       - name: Publish to NuGet
-        run: dotnet nuget push "artifacts/HtmlMailControlWpf.0.0.15.nupkg" --api-key "$env:PACKAGE_TOKEN_NUGET" --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push "artifacts/HtmlMailControlWpf.0.0.16.nupkg" --api-key "$env:PACKAGE_TOKEN_NUGET" --source https://api.nuget.org/v3/index.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.16] - 2022-12-30
+
+- 初期化時の `Cannot convert '<null>' from type '<null>' to type 'System.Uri' for...` 警告抑止
+
 ## [0.0.15] - 2022-11-11
 
 ### Changed
 
-- <meta> タグの Content-Type での指定Encodingに対応
+- <meta> タグの Content-Type での指定Encodingに対応Cannot convert '<null>' from type '<null>' to type 'System.Uri' for
 	- unicode
 	- iso-2022-jp
 	- shift_jis

--- a/HtmlMailControlWpf/HtmlMailControl.xaml
+++ b/HtmlMailControlWpf/HtmlMailControl.xaml
@@ -10,7 +10,7 @@
              d:DesignHeight="450" d:DesignWidth="800"
              DataContextChanged="UserControl_DataContextChanged">
     <Grid>
-        <wv2:WebView2 Name="webView" Source="{Binding Path=SourceUri, ElementName=Control}" >
+        <wv2:WebView2 Name="webView" Source="{Binding Path=SourceUri, ElementName=Control, TargetNullValue=about:blank}" >
         </wv2:WebView2>
     </Grid>
 </UserControl>

--- a/HtmlMailControlWpf/HtmlMailControlWpf.csproj
+++ b/HtmlMailControlWpf/HtmlMailControlWpf.csproj
@@ -6,7 +6,7 @@
 
     <PackageId>HtmlMailControlWpf</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>0.0.15</Version>
+    <Version>0.0.16</Version>
     <Authors>Y.Arimitsu</Authors>
     <Company>Y.Arimitsu</Company>
     <RepositoryUrl>https://github.com/YoshikazuArimitsu/HtmlMailViewerWpf</RepositoryUrl>


### PR DESCRIPTION
初期化時のバインドエラー改修

https://learn.microsoft.com/ja-jp/dotnet/api/system.windows.data.bindingbase.targetnullvalue?view=windowsdesktop-7.0
TargetNullValue = about:black を明示的に設定して回避する。